### PR TITLE
Fix Groovy regex usage

### DIFF
--- a/groovytest/target/classes/dsl/GroovyScript_rule.dsl
+++ b/groovytest/target/classes/dsl/GroovyScript_rule.dsl
@@ -4,7 +4,7 @@ import groovy.transform.BaseScript
 rule {
     metadata {
         gender = context?.student?.priority?.gender
-        valid = gender != null && gender == ~ "\\w[Male, Female]
+        valid = gender != null && gender ==~ /(Male|Female)/
         println "logic.valid=$valid"
     }
 }


### PR DESCRIPTION
## Summary
- fix invalid regex comparison in Groovy DSL file

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443195f03883239492045107d58c00